### PR TITLE
feat: add ctx.replyWithAutoDestructiveMessage and ctx.loadDatabase fu…

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ NODE_ENV=development
 BOT_TOKEN=your-bot-token-here
 DATA_PATH=./data
 LOCALES_PATH=./locales
+MESSAGE_TIMEOUT_ENABLED=true
 MESSAGE_TIMEOUT_IN_MINUTES=2
 EOL
 ```

--- a/README.md
+++ b/README.md
@@ -40,6 +40,19 @@ The bot currently replies in Portuguese by default, and parses names of countrie
     - [x] Portuguese: `/ajuda <assunto> <topico>`
  - [x] Ping all admins:
     - [x] `/ping_admins`, `/admins`, `/eita`
+ - [x] Message Auto Deletion:
+    - [x] Configurable through the `MESSAGE_TIMEOUT_IN_MINUTES` environment variable. Default is `2`.
+    - [x] Feature can be toggled through the `MESSAGE_TIMEOUT_ENABLED` environment variable. Default is `true`.
+    - [x] Deletes both command and reply messages after timeout is reached.
+    - [x] Deletes all interactions that were replied with error messages.
+    - [x] Deletes messages from the following commands:
+      - `/leave`
+      - `/find_member`
+      - `/register_member_at`
+      - `/find_members_at` (only if no members are found)
+      - `/ping_members_at` (only if no members are found)
+      - `/list_country_member_count` (only if no members are registered)
+      - `/rank_country_member_count` (only if no members are registered)
 
 ## Developing
 
@@ -64,6 +77,7 @@ NODE_ENV=development
 BOT_TOKEN=your-bot-token-here
 DATA_PATH=./data
 LOCALES_PATH=./locales
+MESSAGE_TIMEOUT_IN_MINUTES=2
 EOL
 ```
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "author": "Armando Magalhães <armando.mag95@gmail.com>",
   "license": "MIT",
   "dependencies": {
+    "await-to-js": "^3.0.0",
     "dotenv": "^8.2.0",
     "got": "^11.8.2",
     "i18n-iso-countries": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "author": "Armando Magalhães <armando.mag95@gmail.com>",
   "license": "MIT",
   "dependencies": {
+    "async-retry": "^1.3.1",
     "await-to-js": "^3.0.0",
     "dotenv": "^8.2.0",
     "got": "^11.8.2",
@@ -22,6 +23,7 @@
     "yup": "^0.32.9"
   },
   "devDependencies": {
+    "@types/async-retry": "^1.4.2",
     "@types/jest": "^26.0.22",
     "@types/lowdb": "^1.0.9",
     "@types/mkdirp": "^1.0.1",

--- a/src/autoDeleteMessages.ts
+++ b/src/autoDeleteMessages.ts
@@ -20,33 +20,34 @@ export const runMessageRecycling = async (
     const id = Number(unsafeId);
 
     try {
-      ctx.logger.info(`Trying to delete message`, {
-        id,
-        chatId: ctx.chat?.id,
-      });
+      ctx.logger.info(
+        `Trying to delete expired message with id "${id}" from the chat "${ctx.chat?.id}"`
+      );
 
       await ctx.deleteMessage(id);
 
       ctx.logger.info(
-        `Deleted auto delete scheduled message with id "${id}"`
+        `Deleted expired message with id "${id}" from the chat "${ctx.chat?.id}"`
       );
     } catch (err) {
-      ctx.logger.warn(`Failed to delete message with id "${id}"`);
+      ctx.logger.warn(
+        `Failed to delete expired message with id "${id}" from the chat "${ctx.chat?.id}"`
+      );
     }
 
     try {
       ctx.logger.info(
-        `Trying to delete message with id "${id}" from the database`
+        `Trying to delete expired message with id "${id}" from the database`
       );
 
       await database.removeAutoDeleteMessage(id);
 
       ctx.logger.info(
-        `Deleted auto delete scheduled message with id "${id}" from the database`
+        `Deleted expired message with id "${id}" from the database`
       );
     } catch (err) {
       ctx.logger.warn(
-        `Failed to delete message with id "${id}" from the database`
+        `Failed to delete expired message with id "${id}" from the database`
       );
     }
   });

--- a/src/autoDeleteMessages.ts
+++ b/src/autoDeleteMessages.ts
@@ -10,7 +10,7 @@ export const runMessageRecycling = async (
 ): Promise<void> => {
   const database = await ctx.loadDatabase();
   const messages = database.getAutoDeleteMessages();
-  const messageTimeout = 1;
+  const messageTimeout = ctx.config.messageTimeoutInMinutes;
 
   Object.entries(messages).map(async ([unsafeId, createdAt]) => {
     if (!expired(createdAt, messageTimeout)) {
@@ -18,20 +18,21 @@ export const runMessageRecycling = async (
     }
 
     const id = Number(unsafeId);
+    const chatId = ctx.chat?.id;
 
     try {
       ctx.logger.info(
-        `Trying to delete expired message with id "${id}" from the chat "${ctx.chat?.id}"`
+        `Trying to delete expired message with id "${id}" from the chat "${chatId}"`
       );
 
       await ctx.deleteMessage(id);
 
       ctx.logger.info(
-        `Deleted expired message with id "${id}" from the chat "${ctx.chat?.id}"`
+        `Deleted expired message with id "${id}" from the chat "${chatId}"`
       );
     } catch (err) {
       ctx.logger.warn(
-        `Failed to delete expired message with id "${id}" from the chat "${ctx.chat?.id}"`
+        `Failed to delete expired message with id "${id}" from the chat "${chatId}"`
       );
     }
 

--- a/src/autoDeleteMessages.ts
+++ b/src/autoDeleteMessages.ts
@@ -40,8 +40,8 @@ export const runMessageRecycling = async (
             `[Attempt No ${attempt}]: Failed to delete expired message with id "${id}" from the chat "${chatId}"`
           );
 
-          // @ts-ignore
           const errorMessage =
+            // @ts-ignore
             deleteChatMessageError.response.description;
 
           if (

--- a/src/autoDeleteMessages.ts
+++ b/src/autoDeleteMessages.ts
@@ -1,23 +1,53 @@
 import { BotContext } from './context';
 
-export interface AutoDeleteMessage {
-  [messageId: number]: number;
-}
+const expired = (createdAt: number, timeout: number) => {
+  const minute = 60000;
+  return Math.floor((Date.now() - createdAt) / minute) >= timeout;
+};
 
 export const runMessageRecycling = async (
   ctx: BotContext
 ): Promise<void> => {
-  const database = ctx.database;
+  const database = await ctx.loadDatabase();
   const messages = database.getAutoDeleteMessages();
-  const minute = 60000;
-  const recycleTimeout = 1;
+  const messageTimeout = 1;
 
-  Object.entries(messages).map(async ([id, createdAt]) => {
-    if (
-      Math.floor((Date.now() - createdAt) / minute) >= recycleTimeout
-    ) {
-      await ctx.deleteMessage(+id);
-      await database.removeAutoDeleteMessage(+id);
+  Object.entries(messages).map(async ([unsafeId, createdAt]) => {
+    if (!expired(createdAt, messageTimeout)) {
+      return;
+    }
+
+    const id = Number(unsafeId);
+
+    try {
+      ctx.logger.info(`Trying to delete message`, {
+        id,
+        chatId: ctx.chat?.id,
+      });
+
+      await ctx.deleteMessage(id);
+
+      ctx.logger.info(
+        `Deleted auto delete scheduled message with id "${id}"`
+      );
+    } catch (err) {
+      ctx.logger.warn(`Failed to delete message with id "${id}"`);
+    }
+
+    try {
+      ctx.logger.info(
+        `Trying to delete message with id "${id}" from the database`
+      );
+
+      await database.removeAutoDeleteMessage(id);
+
+      ctx.logger.info(
+        `Deleted auto delete scheduled message with id "${id}" from the database`
+      );
+    } catch (err) {
+      ctx.logger.warn(
+        `Failed to delete message with id "${id}" from the database`
+      );
     }
   });
 };

--- a/src/commands/deregisterMemberFrom.ts
+++ b/src/commands/deregisterMemberFrom.ts
@@ -13,7 +13,7 @@ export const cmdDeregisterMemberFrom: Middleware<BotContext> = async (
   const unsafeCountryName = markdown.escape(ctx.command.args ?? '');
 
   if (!unsafeCountryName) {
-    return ctx.replyWithMarkdown(
+    return ctx.replyWithAutoDestructiveMessage(
       i18n.t('errors.noCountryProvided', {
         mention: ctx.safeUser.mention,
       })
@@ -23,7 +23,7 @@ export const cmdDeregisterMemberFrom: Middleware<BotContext> = async (
   const countryCode = getCountryCodeForText(unsafeCountryName);
 
   if (!countryCode) {
-    return ctx.replyWithMarkdown(
+    return ctx.replyWithAutoDestructiveMessage(
       i18n.t('errors.failedToIdentifyCountry', {
         mention: ctx.safeUser.mention,
         countryName: unsafeCountryName,
@@ -33,7 +33,7 @@ export const cmdDeregisterMemberFrom: Middleware<BotContext> = async (
 
   await ctx.database.removeMemberFrom(ctx.safeUser.id, countryCode);
 
-  return ctx.replyWithMarkdown(
+  return ctx.replyWithAutoDestructiveMessage(
     i18n.t('location.memberDeregisteredFromLocation', {
       mention: ctx.safeUser.mention,
       country: getCountryNameForCountryCode(countryCode),

--- a/src/commands/findMember.ts
+++ b/src/commands/findMember.ts
@@ -4,7 +4,6 @@ import { getCountryNameForCountryCode } from '../countries';
 
 export const cmdFindMember: Middleware<BotContext> = async (ctx) => {
   const i18n = ctx.i18n;
-  const database = ctx.database;
   const locations = await ctx.database.findMember(ctx.safeUser.id);
 
   const message =
@@ -19,9 +18,5 @@ export const cmdFindMember: Middleware<BotContext> = async (ctx) => {
             .join(', '),
         });
 
-  const messageSent = await ctx.replyWithMarkdown(message);
-
-  await database.addAutoDeleteMessage(messageSent.message_id);
-
-  return messageSent;
+  return ctx.replyWithAutoDestructiveMessage(message);
 };

--- a/src/commands/findMembersAt.ts
+++ b/src/commands/findMembersAt.ts
@@ -14,7 +14,7 @@ export const cmdFindMembersAt: Middleware<BotContext> = async (
   const unsafeCountryName = markdown.escape(ctx.command.args ?? '');
 
   if (!unsafeCountryName) {
-    return ctx.replyWithMarkdown(
+    return ctx.replyWithAutoDestructiveMessage(
       i18n.t('errors.noCountryProvided', {
         mention: ctx.safeUser.mention,
       })
@@ -24,7 +24,7 @@ export const cmdFindMembersAt: Middleware<BotContext> = async (
   const countryCode = getCountryCodeForText(unsafeCountryName);
 
   if (!countryCode) {
-    return ctx.replyWithMarkdown(
+    return ctx.replyWithAutoDestructiveMessage(
       i18n.t('errors.failedToIdentifyCountry', {
         mention: ctx.safeUser.mention,
         countryName: unsafeCountryName,
@@ -40,17 +40,21 @@ export const cmdFindMembersAt: Middleware<BotContext> = async (
     })
   );
 
-  const message =
-    members.length === 0
-      ? i18n.t('location.noMembersAtLocation', {
-          mention: ctx.safeUser.mention,
-          country: getCountryNameForCountryCode(countryCode),
-        })
-      : i18n.t('location.membersAtLocation', {
-          mention: ctx.safeUser.mention,
-          members: members.join(', '),
-          country: getCountryNameForCountryCode(countryCode),
-        });
+  const hasNoMembers = members.length === 0;
 
-  return ctx.replyWithMarkdown(message);
+  const message = hasNoMembers
+    ? i18n.t('location.noMembersAtLocation', {
+        mention: ctx.safeUser.mention,
+        country: getCountryNameForCountryCode(countryCode),
+      })
+    : i18n.t('location.membersAtLocation', {
+        mention: ctx.safeUser.mention,
+        members: members.join(', '),
+        country: getCountryNameForCountryCode(countryCode),
+      });
+
+  return ctx.replyWithAutoDestructiveMessage(message, {
+    deleteReplyMessage: hasNoMembers,
+    deleteCommandMessage: hasNoMembers,
+  });
 };

--- a/src/commands/listCountryMemberCount.ts
+++ b/src/commands/listCountryMemberCount.ts
@@ -23,7 +23,7 @@ export const cmdListCountryMemberCount: Middleware<BotContext> = async (
     .sort((a, b) => a.localeCompare(b));
 
   if (locationCount.length === 0)
-    return ctx.replyWithMarkdown(
+    return ctx.replyWithAutoDestructiveMessage(
       i18n.t('listing.noMembers', {
         mention: ctx.safeUser.mention,
       })

--- a/src/commands/pingMembersAt.ts
+++ b/src/commands/pingMembersAt.ts
@@ -14,7 +14,7 @@ export const cmdPingMemberAt: Middleware<BotContext> = async (
   const unsafeCountryName = markdown.escape(ctx.command.args ?? '');
 
   if (!unsafeCountryName) {
-    return ctx.replyWithMarkdown(
+    return ctx.replyWithAutoDestructiveMessage(
       i18n.t('errors.noCountryProvided', {
         mention: ctx.safeUser.mention,
       })
@@ -24,7 +24,7 @@ export const cmdPingMemberAt: Middleware<BotContext> = async (
   const countryCode = getCountryCodeForText(unsafeCountryName);
 
   if (!countryCode) {
-    return ctx.replyWithMarkdown(
+    return ctx.replyWithAutoDestructiveMessage(
       i18n.t('errors.failedToIdentifyCountry', {
         mention: ctx.safeUser.mention,
         countryName: unsafeCountryName,
@@ -40,17 +40,21 @@ export const cmdPingMemberAt: Middleware<BotContext> = async (
     })
   );
 
-  const message =
-    members.length === 0
-      ? i18n.t('location.noMembersAtLocation', {
-          mention: ctx.safeUser.mention,
-          country: getCountryNameForCountryCode(countryCode),
-        })
-      : i18n.t('location.membersAtLocation', {
-          mention: ctx.safeUser.mention,
-          members: members.join(', '),
-          country: getCountryNameForCountryCode(countryCode),
-        });
+  const hasNoMembers = members.length === 0;
 
-  return ctx.replyWithMarkdown(message);
+  const message = hasNoMembers
+    ? i18n.t('location.noMembersAtLocation', {
+        mention: ctx.safeUser.mention,
+        country: getCountryNameForCountryCode(countryCode),
+      })
+    : i18n.t('location.membersAtLocation', {
+        mention: ctx.safeUser.mention,
+        members: members.join(', '),
+        country: getCountryNameForCountryCode(countryCode),
+      });
+
+  return ctx.replyWithAutoDestructiveMessage(message, {
+    deleteReplyMessage: hasNoMembers,
+    deleteCommandMessage: hasNoMembers,
+  });
 };

--- a/src/commands/rankCountryMemberCount.ts
+++ b/src/commands/rankCountryMemberCount.ts
@@ -28,23 +28,22 @@ export const cmdRankCountryMemberCount: Middleware<BotContext> = async (
       return 0;
     });
 
-  if (locationCount.length == 0)
-    return ctx.replyWithMarkdown(
+  if (locationCount.length == 0) {
+    return ctx.replyWithAutoDestructiveMessage(
       i18n.t('listing.noMembers', {
         mention: ctx.safeUser.mention,
       })
     );
+  }
 
   const counts = locationCount.map((lc) => lc.count);
 
   // Standard competition ranking ("1224" ranking)
-  const locationCountRank = locationCount.map(
-    (countryAndCounts, index) => {
-      const { countryName, count } = countryAndCounts;
-      const rank = counts.indexOf(count) + 1;
-      return `${rank}. ${countryName}: ${count}`;
-    }
-  );
+  const locationCountRank = locationCount.map((countryAndCounts) => {
+    const { countryName, count } = countryAndCounts;
+    const rank = counts.indexOf(count) + 1;
+    return `${rank}. ${countryName}: ${count}`;
+  });
 
   return ctx.replyWithMarkdown(locationCountRank.join('\n'));
 };

--- a/src/commands/registerMemberAt.ts
+++ b/src/commands/registerMemberAt.ts
@@ -13,7 +13,7 @@ export const cmdRegisterMemberAt: Middleware<BotContext> = async (
   const unsafeCountryName = markdown.escape(ctx.command.args ?? '');
 
   if (!unsafeCountryName) {
-    return ctx.replyWithMarkdown(
+    return ctx.replyWithAutoDestructiveMessage(
       i18n.t('errors.noCountryProvided', {
         mention: ctx.safeUser.mention,
       })
@@ -23,7 +23,7 @@ export const cmdRegisterMemberAt: Middleware<BotContext> = async (
   const countryCode = getCountryCodeForText(unsafeCountryName);
 
   if (!countryCode) {
-    return ctx.replyWithMarkdown(
+    return ctx.replyWithAutoDestructiveMessage(
       i18n.t('errors.failedToIdentifyCountry', {
         mention: ctx.safeUser.mention,
         countryName: unsafeCountryName,
@@ -35,7 +35,7 @@ export const cmdRegisterMemberAt: Middleware<BotContext> = async (
   const userId = ctx.safeUser.id;
 
   if (database.hasMemberRegistered(userId, countryCode)) {
-    return ctx.replyWithMarkdown(
+    return ctx.replyWithAutoDestructiveMessage(
       i18n.t('errors.memberAlreadyRegistered', {
         mention: ctx.safeUser.mention,
       })
@@ -44,7 +44,7 @@ export const cmdRegisterMemberAt: Middleware<BotContext> = async (
 
   await database.addMemberLocation(userId, countryCode);
 
-  return ctx.replyWithMarkdown(
+  return ctx.replyWithAutoDestructiveMessage(
     i18n.t('location.memberRegisteredAtLocation', {
       mention: ctx.safeUser.mention,
       country: getCountryNameForCountryCode(countryCode),

--- a/src/config.ts
+++ b/src/config.ts
@@ -32,6 +32,7 @@ const ConfigSchema = yup.object({
     .string()
     .required(createRequiredErrMessage('DATA_PATH')),
   localesPath: yup.string().default('./locales'),
+  messageTimeoutInMinutes: yup.number().integer().default(2),
 });
 
 export const loadConfiguration = async () => {
@@ -40,6 +41,7 @@ export const loadConfiguration = async () => {
     botToken: process.env.BOT_TOKEN,
     dataPath: process.env.DATA_PATH,
     localesPath: process.env.LOCALES_PATH,
+    messageTimeoutInMinutes: process.env.MESSAGE_TIMEOUT_IN_MINUTES,
   };
 
   const config = await ConfigSchema.validate(unsafeConfig);

--- a/src/config.ts
+++ b/src/config.ts
@@ -33,6 +33,7 @@ const ConfigSchema = yup.object({
     .required(createRequiredErrMessage('DATA_PATH')),
   localesPath: yup.string().default('./locales'),
   messageTimeoutInMinutes: yup.number().integer().default(2),
+  messageTimeoutEnabled: yup.boolean().default(true),
 });
 
 export const loadConfiguration = async () => {
@@ -41,6 +42,9 @@ export const loadConfiguration = async () => {
     botToken: process.env.BOT_TOKEN,
     dataPath: process.env.DATA_PATH,
     localesPath: process.env.LOCALES_PATH,
+    messageTimeoutEnabled: process.env.MESSAGE_TIMEOUT_ENABLED
+      ? process.env.MESSAGE_TIMEOUT_ENABLED === 'true'
+      : undefined,
     messageTimeoutInMinutes: process.env.MESSAGE_TIMEOUT_IN_MINUTES,
   };
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -4,11 +4,22 @@ import TelegrafI18n from 'telegraf-i18n';
 import { Config } from './config';
 import { DatabaseInstance } from './database';
 
+interface AutoDestructiveMessageOptions {
+  deleteCommandMessage: boolean;
+  deleteReplyMessage: boolean;
+}
+
 export interface BotContext extends Context {
   config: Config;
   database: DatabaseInstance;
+  loadDatabase: () => Promise<DatabaseInstance>;
+  replyWithAutoDestructiveMessage: (
+    markdownMessage: string,
+    options?: AutoDestructiveMessageOptions
+  ) => ReturnType<Context['replyWithMarkdown']>;
   logger: pino.Logger;
   i18n: TelegrafI18n;
+  autoDeleteInterval?: NodeJS.Timeout;
   safeUser: {
     mention: string;
     id: number;

--- a/src/context.ts
+++ b/src/context.ts
@@ -19,7 +19,6 @@ export interface BotContext extends Context {
   ) => ReturnType<Context['replyWithMarkdown']>;
   logger: pino.Logger;
   i18n: TelegrafI18n;
-  autoDeleteInterval?: NodeJS.Timeout;
   safeUser: {
     mention: string;
     id: number;

--- a/src/database.ts
+++ b/src/database.ts
@@ -5,11 +5,10 @@ import pino from 'pino';
 import low from 'lowdb';
 import FileAsync from 'lowdb/adapters/FileAsync';
 import { Alpha2Code } from 'i18n-iso-countries';
-import { AutoDeleteMessage } from './autoDeleteMessages';
 
 interface DatabaseSchema {
   locationIndex: Partial<Record<Alpha2Code, number[]>>;
-  autoDeleteMessages: AutoDeleteMessage;
+  autoDeleteMessages: Record<string, number>;
 }
 
 export interface DatabaseInstance {
@@ -29,7 +28,7 @@ export interface DatabaseInstance {
   getLocationIndex: () => DatabaseSchema['locationIndex'];
   findMember: (userId: number) => Promise<Alpha2Code[]>;
   addAutoDeleteMessage: (messageId: number) => Promise<void>;
-  getAutoDeleteMessages: () => AutoDeleteMessage;
+  getAutoDeleteMessages: () => DatabaseSchema['autoDeleteMessages'];
   removeAutoDeleteMessage: (messageId: number) => Promise<void>;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,6 @@ const main = async () => {
   bot.use(
     createContextMiddleware({
       config,
-      logger: logger.child({ source: 'database' }),
     })
   );
 

--- a/src/middlewares/createContextMiddleware.ts
+++ b/src/middlewares/createContextMiddleware.ts
@@ -104,7 +104,9 @@ export const createContextMiddleware = ({ config }: Props) => {
       messageDeletionIntervals[chatId];
 
     if (!chatMessageRecyclingInterval) {
-      ctx.logger.info('Creating auto delete interval.');
+      ctx.logger.info(
+        `Creating message deletion interval for chat "${chatId}".`
+      );
       messageDeletionIntervals[chatId] = setInterval(() => {
         runMessageRecycling(ctx);
       }, 10000);

--- a/src/middlewares/createContextMiddleware.ts
+++ b/src/middlewares/createContextMiddleware.ts
@@ -1,4 +1,3 @@
-import pino from 'pino';
 import { Middleware } from 'telegraf';
 import { runMessageRecycling } from '../autoDeleteMessages';
 import { CommandDescriptions } from '../command';
@@ -9,21 +8,29 @@ import { createMemberMention } from '../member';
 
 interface Props {
   config: Config;
-  logger: pino.Logger;
 }
 
-export const createContextMiddleware = ({
-  config,
-  logger,
-}: Props) => {
-  let interval: NodeJS.Timeout;
+type MessageDeletionIntervals = Record<string, NodeJS.Timeout>;
 
+/**
+ * Message Deletion Intervals
+ *
+ * This object is mutated during runtime to include
+ * interval instances for message auto deletion for
+ * each chat being used.
+ *
+ * The key of this object will always be the chat id,
+ * and the value will be an instance of NodeJS.Timeout.
+ */
+const messageDeletionIntervals: MessageDeletionIntervals = {};
+
+export const createContextMiddleware = ({ config }: Props) => {
   const middleware: Middleware<BotContext> = async (ctx, next) => {
     /**
      * telegraf-i18n uses the user session to determine
      * which locale to use. This basically forces
      * all answers to be sent in ptbr.
-     */
+     **/
     ctx.i18n.locale('ptbr');
 
     const chatId = ctx?.chat?.id;
@@ -50,13 +57,41 @@ export const createContextMiddleware = ({
       return ctx.reply(ctx.i18n.t('failedToIdentifyUser'));
     }
 
-    const database = await createDatabase(
-      chatId,
-      config.dataPath,
-      logger
-    );
+    const logger = ctx.logger.child({ source: 'database' });
 
-    ctx.database = database;
+    const loadDatabase = () => {
+      return createDatabase(chatId, config.dataPath, logger);
+    };
+
+    const replyWithAutoDestructiveMessage: BotContext['replyWithAutoDestructiveMessage'] = async (
+      markdownMessage,
+      options = {
+        deleteReplyMessage: true,
+        deleteCommandMessage: true,
+      }
+    ) => {
+      const messageSent = await ctx.replyWithMarkdown(
+        markdownMessage
+      );
+
+      if (options.deleteCommandMessage && ctx.message?.message_id) {
+        await ctx.database.addAutoDeleteMessage(
+          ctx.message?.message_id
+        );
+      }
+
+      if (options.deleteReplyMessage) {
+        await ctx.database.addAutoDeleteMessage(
+          messageSent.message_id
+        );
+      }
+
+      return messageSent;
+    };
+
+    ctx.replyWithAutoDestructiveMessage = replyWithAutoDestructiveMessage;
+    ctx.loadDatabase = loadDatabase;
+    ctx.database = await loadDatabase();
     ctx.config = config;
     ctx.safeUser = {
       id: ctx.from.id,
@@ -65,13 +100,19 @@ export const createContextMiddleware = ({
 
     ctx.setMyCommands(CommandDescriptions);
 
-    if (!interval) {
-      interval = setInterval(() => callMessageRecycling(), 5000);
-    }
+    const chatMessageRecyclingInterval =
+      messageDeletionIntervals[chatId];
 
-    const callMessageRecycling = () => {
-      runMessageRecycling(ctx);
-    };
+    if (!chatMessageRecyclingInterval) {
+      ctx.logger.info('Creating auto delete interval.');
+      messageDeletionIntervals[chatId] = setInterval(() => {
+        runMessageRecycling(ctx);
+      }, 10000);
+
+      process.on('SIGINT', () =>
+        clearInterval(messageDeletionIntervals[chatId])
+      );
+    }
 
     return next();
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -879,6 +879,11 @@ atomic-sleep@^1.0.0:
   resolved "https://registry.yarnpkg.com/atomic-sleep/-/atomic-sleep-1.0.0.tgz#eb85b77a601fc932cfe432c5acd364a9e2c9075b"
   integrity sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==
 
+await-to-js@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/await-to-js/-/await-to-js-3.0.0.tgz#70929994185616f4675a91af6167eb61cc92868f"
+  integrity sha512-zJAaP9zxTcvTHRlejau3ZOY4V7SRpiByf3/dxx2uyKxxor19tpmpV2QRsTKikckwhaPmr2dVpxxMr7jOCYVp5g==
+
 aws-sign2@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -536,6 +536,13 @@
   dependencies:
     defer-to-connect "^2.0.0"
 
+"@types/async-retry@^1.4.2":
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/@types/async-retry/-/async-retry-1.4.2.tgz#7f910188cd3893b51e32df51765ee8d5646053e3"
+  integrity sha512-GUDuJURF0YiJZ+CBjNQA0+vbP/VHlJbB0sFqkzsV7EcOPRfurVonXpXKAt3w8qIjM1TEzpz6hc6POocPvHOS3w==
+  dependencies:
+    "@types/retry" "*"
+
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.7":
   version "7.1.12"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.12.tgz#4d8e9e51eb265552a7e4f1ff2219ab6133bdfb2d"
@@ -681,6 +688,11 @@
   integrity sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==
   dependencies:
     "@types/node" "*"
+
+"@types/retry@*":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.0.tgz#2b35eccfcee7d38cd72ad99232fbd58bffb3c84d"
+  integrity sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==
 
 "@types/sonic-boom@*":
   version "0.7.0"
@@ -863,6 +875,13 @@ assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
   integrity sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=
+
+async-retry@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/async-retry/-/async-retry-1.3.1.tgz#139f31f8ddce50c0870b0ba558a6079684aaed55"
+  integrity sha512-aiieFW/7h3hY0Bq5d+ktDBejxuwR78vRu9hDUdR8rNhSaQ29VzPL4AoIRG7D/c7tdenwOcKvgPM6tIxB3cB6HA==
+  dependencies:
+    retry "0.12.0"
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -3809,6 +3828,11 @@ ret@~0.1.10:
   version "0.1.15"
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
+
+retry@0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
+  integrity sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=
 
 rimraf@^3.0.0:
   version "3.0.2"


### PR DESCRIPTION
this PR adds a bunch of changes to your original changes

in a nutshell, this:

 - adds a `ctx.replyWithAutoDestructiveMessage` function, which will send the message and based on options given by the caller, decide if the command message or the reply messages should be recycled on the next interval.
 - adds a `ctx.loadDatabase` function: this function is handy for the messageRecycleInterval to be able to reload the database for a specific chatId in a random moment of time and still have the most updated version of it.
 - creates a `messageIntervalStore` object in memory that will hold the instances of these intervals in between messages. Unfortunately, it still needs the first message to be sent in the group to be initialized. 
 - renames all commands that use `ctx.replyWithMarkdown` to use the proper calls with auto-destructive message.